### PR TITLE
Added expire_leaderboard and expire_leaderboard_at methods and specs.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -252,6 +252,8 @@ Use this method to do bulk insert of data, but be mindful of the amount of data 
   remove_members_in_score_range(min_score, max_score): Remove members from the leaderboard within a score range
   percentile_for(member): Calculate the percentile for a given member
   page_for(member, page_size): Determine the page where a member falls in the leaderboard
+  expire_leaderboard(seconds): Expire the leaderboard in a set number of seconds.
+  expire_leaderboard_at(timestamp): Expire the leaderboard at a specific UNIX timestamp.
   rank_members(members_and_scores): Rank an array of members in the leaderboard where you can call via (member_name, score) or pass in an array of [member_name, score]
   merge_leaderboards(destination, keys, options = {:aggregate => :min}): Merge leaderboards given by keys with this leaderboard into destination
   intersect_leaderboards(destination, keys, options = {:aggregate => :min}): Intersect leaderboards given by keys with this leaderboard into destination

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -478,6 +478,44 @@ class Leaderboard
 
     (rank_for_member.to_f / page_size.to_f).ceil    
   end
+
+  # Expire the current leaderboard in a set number of seconds. Do not use this with 
+  # leaderboards that utilize member data as there is no facility to cascade the 
+  # expiration out to the keys for the member data.
+  #
+  # @param seconds [int] Number of seconds after which the leaderboard will be expired.
+  def expire_leaderboard(seconds)
+    expire_leaderboard_for(@leaderboard_name, seconds)
+  end
+
+  # Expire the given leaderboard in a set number of seconds. Do not use this with 
+  # leaderboards that utilize member data as there is no facility to cascade the 
+  # expiration out to the keys for the member data.
+  #
+  # @param leaderboard_name [String] Name of the leaderboard.
+  # @param seconds [int] Number of seconds after which the leaderboard will be expired.
+  def expire_leaderboard_for(leaderboard_name, seconds)
+    @redis_connection.expire(leaderboard_name, seconds)
+  end
+
+  # Expire the current leaderboard at a specific UNIX timestamp. Do not use this with 
+  # leaderboards that utilize member data as there is no facility to cascade the 
+  # expiration out to the keys for the member data.
+  #
+  # @param timestamp [int] UNIX timestamp at which the leaderboard will be expired.
+  def expire_leaderboard_at(timestamp)
+    expire_leaderboard_at_for(@leaderboard_name, timestamp)
+  end
+
+  # Expire the given leaderboard at a specific UNIX timestamp. Do not use this with 
+  # leaderboards that utilize member data as there is no facility to cascade the 
+  # expiration out to the keys for the member data.
+  #
+  # @param leaderboard_name [String] Name of the leaderboard.
+  # @param timestamp [int] UNIX timestamp at which the leaderboard will be expired.
+  def expire_leaderboard_at_for(leaderboard_name, timestamp)
+    @redis_connection.expireat(leaderboard_name, timestamp)
+  end
     
   # Retrieve a page of leaders from the leaderboard.
   # 

--- a/spec/leaderboard_spec.rb
+++ b/spec/leaderboard_spec.rb
@@ -546,6 +546,26 @@ describe 'Leaderboard' do
     @leaderboard.page_for('member_1', 10).should be(2)
   end
 
+  it 'should set an expire on the leaderboard' do
+    rank_members_in_leaderboard
+
+    @leaderboard.expire_leaderboard(3)    
+    @redis_connection.ttl(@leaderboard.leaderboard_name).tap do |ttl|
+      ttl.should be > 1
+      ttl.should be <= 3
+    end
+  end
+
+  it 'should set an expire on the leaderboard using a timestamp' do
+    rank_members_in_leaderboard
+
+    @leaderboard.expire_leaderboard_at((Time.now + 10).to_i)
+    @redis_connection.ttl(@leaderboard.leaderboard_name).tap do |ttl|
+      ttl.should be > 1
+      ttl.should be <= 10
+    end
+  end
+
   it 'should allow you to rank multiple members with a variable number of arguments' do
     @leaderboard.total_members.should be(0)
     @leaderboard.rank_members('member_1', 1, 'member_10', 10)


### PR DESCRIPTION
This adds functionality to be able to set an expiration in either seconds or at a specific timestamp for a given leaderboard.
