### PR TITLE
Get entire leaderboard

### DIFF
--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -576,6 +576,42 @@ class Leaderboard
 
   alias_method :members_in, :leaders_in
 
+  # Retrieve all leaders from the leaderboard.
+  #
+  # @param options [Hash] Options to be used when retrieving the page from the leaderboard.
+  #
+  # @return the leaders from the leaderboard.
+  def all_leaders(options = {})
+    all_leaders_from(@leaderboard_name, options)
+  end
+
+  alias_method :all_members, :all_leaders
+
+  # Retrieves all leaders from the named leaderboard.
+  #
+  # @param leaderboard_name [String] Name of the leaderboard.
+  # @param options [Hash] Options to be used when retrieving the page from the named leaderboard.
+  #
+  # @return the named leaderboard.
+  def all_leaders_from(leaderboard_name, options = {})
+    leaderboard_options = DEFAULT_LEADERBOARD_REQUEST_OPTIONS.dup
+    leaderboard_options.merge!(options)
+
+    if @reverse
+      raw_leader_data = @redis_connection.zrange(leaderboard_name, 0, -1, :with_scores => false)
+    else
+      raw_leader_data = @redis_connection.zrevrange(leaderboard_name, 0, -1, :with_scores => false)
+    end
+
+    if raw_leader_data
+      return ranked_in_list_in(leaderboard_name, raw_leader_data, leaderboard_options)
+    else
+      return []
+    end
+  end
+
+  alias_method :all_members_from, :all_leaders_from
+
   # Retrieve members from the leaderboard within a given score range.
   #
   # @param minimum_score [float] Minimum score (inclusive).

--- a/spec/leaderboard_spec.rb
+++ b/spec/leaderboard_spec.rb
@@ -141,6 +141,22 @@ describe 'Leaderboard' do
     leaders.size.should be(1)
   end
 
+  %w(members leaders).each do |method|
+    it "should return the entire leaderboard when you call 'all_#{method}'" do
+      rank_members_in_leaderboard(27)
+
+      @leaderboard.total_members.should be(27)
+
+      members = @leaderboard.send("all_#{method}")
+
+      members.size.should be(27)
+      members[0][:member].should == 'member_27'
+      members[-2][:member].should == 'member_2'
+      members[-1][:member].should == 'member_1'
+      members[-1][:score].to_i.should be(1)
+    end
+  end
+
   it 'should allow you to retrieve members in a given score range' do
     rank_members_in_leaderboard(Leaderboard::DEFAULT_PAGE_SIZE)
 


### PR DESCRIPTION
If I have a leaderboard that I know is going to be a variable--but modest--size, I'd like to retrieve the whole thing in one request without pagination or specifying an arbitrarily large page_size.

Here's a sample implementation. I'm willing to do some refactoring to reduce duplication between the paged and unpaged versions of this if you're interested in including this.
