### PR TITLE
Allow for customization of member_data namespace

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,7 +51,8 @@ DEFAULT_OPTIONS = {
   :member_key => :member,
   :rank_key => :rank,
   :score_key => :score,
-  :member_data_key => :member_data
+  :member_data_key => :member_data,
+  :member_data_namespace => 'member_data'
 }
 ```
 

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -14,7 +14,8 @@ class Leaderboard
     :member_key => :member,
     :rank_key => :rank,
     :score_key => :score,
-    :member_data_key => :member_data
+    :member_data_key => :member_data,
+    :member_data_namespace => 'member_data'
   }
 
   # Default Redis host: localhost
@@ -78,6 +79,7 @@ class Leaderboard
     @rank_key = leaderboard_options[:rank_key]
     @score_key = leaderboard_options[:score_key]
     @member_data_key = leaderboard_options[:member_data_key]
+    @member_data_namespace = leaderboard_options[:member_data_namespace]
 
     @redis_connection = redis_options[:redis_connection]
     unless @redis_connection.nil?
@@ -972,7 +974,7 @@ class Leaderboard
   #
   # @return a key in the form of +leaderboard_name:member_data+
   def member_data_key(leaderboard_name)
-    "#{leaderboard_name}:member_data"
+    "#{leaderboard_name}:#{@member_data_namespace}"
   end
 
   # Validate and return the page size. Returns the +DEFAULT_PAGE_SIZE+ if the page size is less than 1.

--- a/spec/leaderboard_spec.rb
+++ b/spec/leaderboard_spec.rb
@@ -759,4 +759,12 @@ describe 'Leaderboard' do
       leader[:member_data].should be_nil
     end
   end
+
+  it 'should allow you to change the :member_data_namespace option' do
+    @leaderboard = Leaderboard.new('name', {:member_data_namespace => 'md'}, {:host => "127.0.0.1", :db => 15})
+    rank_members_in_leaderboard
+
+    @redis_connection.exists("name:member_data").should be_false
+    @redis_connection.exists("name:md").should be_true
+  end
 end


### PR DESCRIPTION
You can now pass in the `:member_data_namespace => 'md'` option when creating a leaderboard to customize where member data is stored.
