### PR TITLE
Define top(number) helper method

### DIFF
--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -812,6 +812,29 @@ class Leaderboard
     end
   end
 
+  # Retrieve members from the leaderboard within a range from 1 to the number given.
+  #
+  # @param ending_rank [int] Ending rank (inclusive).
+  # @param options [Hash] Options to be used when retrieving the data from the leaderboard.
+  #
+  # @return number from the leaderboard that fall within the given rank range.
+  def top(number, options = {})
+    members_from_rank_range(1, number, options)
+  end
+
+  # Retrieve members from the named leaderboard within a range from 1 to the number given.
+  #
+  # @param leaderboard_name [String] Name of the leaderboard.
+  # @param starting_rank [int] Starting rank (inclusive).
+  # @param ending_rank [int] Ending rank (inclusive).
+  # @param options [Hash] Options to be used when retrieving the data from the leaderboard.
+  #
+  # @return members from the leaderboard that fall within the given rank range.
+  def top_in(leaderboard_name, number, options={})
+    members_from_rank_range_in(leaderboard_name, 1, number, options)
+  end
+
+
   # Retrieve a member at the specified index from the leaderboard.
   #
   # @param position [int] Position in leaderboard.

--- a/spec/competition_ranking_leaderboard_spec.rb
+++ b/spec/competition_ranking_leaderboard_spec.rb
@@ -123,5 +123,48 @@ describe 'CompetitionRankingLeaderboard' do
 
       leaderboard.disconnect
     end
+
+    it 'should allow you to retrieve a given set of members from the leaderboard in a range from 1 to the number given' do
+      @leaderboard = CompetitionRankingLeaderboard.new('ties', Leaderboard::DEFAULT_OPTIONS, {:host => "127.0.0.1", :db => 15})
+      rank_members_in_leaderboard(25)
+
+      members = @leaderboard.top(5)
+      expect(members.size).to be(5)
+      expect(members[0][:member]).to eql('member_25')
+      expect(members[0][:score].to_i).to be(25)
+      expect(members[4][:member]).to eql('member_21')
+
+      members = @leaderboard.top(1)
+      expect(members.size).to be(1)
+      expect(members[0][:member]).to eql('member_25')
+
+      members = @leaderboard.top(26)
+      expect(members.size).to be(25)
+      expect(members[0][:member]).to eql('member_25')
+      expect(members[0][:score].to_i).to be(25)
+      expect(members[24][:member]).to eql('member_1')
+    end
+
+    it 'should allow you to retrieve a given set of members from the named leaderboard in a range from 1 to the number given' do
+      @leaderboard = CompetitionRankingLeaderboard.new('ties', Leaderboard::DEFAULT_OPTIONS, {:host => "127.0.0.1", :db => 15})
+      rank_members_in_leaderboard(25)
+
+      members = @leaderboard.top_in("ties", 5)
+      expect(members.size).to be(5)
+      expect(members[0][:member]).to eql('member_25')
+      expect(members[0][:score].to_i).to be(25)
+      expect(members[4][:member]).to eql('member_21')
+
+      members = @leaderboard.top(1)
+      expect(members.size).to be(1)
+      expect(members[0][:member]).to eql('member_25')
+
+      members = @leaderboard.top(26)
+      expect(members.size).to be(25)
+      expect(members[0][:member]).to eql('member_25')
+      expect(members[0][:score].to_i).to be(25)
+      expect(members[24][:member]).to eql('member_1')
+    end
+
   end
 end

--- a/spec/leaderboard_spec.rb
+++ b/spec/leaderboard_spec.rb
@@ -626,6 +626,46 @@ describe 'Leaderboard' do
     expect(members[24][:member]).to eql('member_1')
   end
 
+  it 'should allow you to retrieve a given set of members from the leaderboard in a range from 1 to the number given' do
+    rank_members_in_leaderboard(25)
+
+    members = @leaderboard.top(5)
+    expect(members.size).to be(5)
+    expect(members[0][:member]).to eql('member_25')
+    expect(members[0][:score].to_i).to be(25)
+    expect(members[4][:member]).to eql('member_21')
+
+    members = @leaderboard.top(1)
+    expect(members.size).to be(1)
+    expect(members[0][:member]).to eql('member_25')
+
+    members = @leaderboard.top(26)
+    expect(members.size).to be(25)
+    expect(members[0][:member]).to eql('member_25')
+    expect(members[0][:score].to_i).to be(25)
+    expect(members[24][:member]).to eql('member_1')
+  end
+
+  it 'should allow you to retrieve a given set of members from the named leaderboard in a range from 1 to the number given' do
+    rank_members_in_leaderboard(25)
+
+    members = @leaderboard.top_in("name", 5)
+    expect(members.size).to be(5)
+    expect(members[0][:member]).to eql('member_25')
+    expect(members[0][:score].to_i).to be(25)
+    expect(members[4][:member]).to eql('member_21')
+
+    members = @leaderboard.top(1)
+    expect(members.size).to be(1)
+    expect(members[0][:member]).to eql('member_25')
+
+    members = @leaderboard.top(26)
+    expect(members.size).to be(25)
+    expect(members[0][:member]).to eql('member_25')
+    expect(members[0][:score].to_i).to be(25)
+    expect(members[24][:member]).to eql('member_1')
+  end
+
   it 'should sort by rank if the :sort_by option is set to :rank' do
     rank_members_in_leaderboard(25)
 

--- a/spec/reverse_leaderboard_spec.rb
+++ b/spec/reverse_leaderboard_spec.rb
@@ -335,6 +335,48 @@ describe 'Leaderboard (reverse option)' do
     expect(members[24][:member]).to eql('member_25')
   end
 
+  it 'should allow you to retrieve a given set of members from the leaderboard in a range from 1 to the number given' do
+    rank_members_in_leaderboard(25)
+
+    members = @leaderboard.top(5)
+    expect(members.size).to be(5)
+    expect(members[0][:member]).to eql('member_1')
+    expect(members[0][:score].to_i).to be(1)
+    expect(members[4][:member]).to eql('member_5')
+
+    members = @leaderboard.top(1)
+    expect(members.size).to be(1)
+    expect(members[0][:member]).to eql('member_1')
+
+    members = @leaderboard.top(26)
+    expect(members.size).to be(25)
+    expect(members[0][:member]).to eql('member_1')
+    expect(members[0][:score].to_i).to be(1)
+    expect(members[24][:member]).to eql('member_25')
+  end
+
+  it 'should allow you to retrieve a given set of members from the named leaderboard in a range from 1 to the number given' do
+    rank_members_in_leaderboard(25)
+
+    members = @leaderboard.top_in("name", 5)
+    expect(members.size).to be(5)
+    expect(members[0][:member]).to eql('member_1')
+    expect(members[0][:score].to_i).to be(1)
+    expect(members[4][:member]).to eql('member_5')
+
+    members = @leaderboard.top(1)
+    expect(members.size).to be(1)
+    expect(members[0][:member]).to eql('member_1')
+
+    members = @leaderboard.top(26)
+    expect(members.size).to be(25)
+    expect(members[0][:member]).to eql('member_1')
+    expect(members[0][:score].to_i).to be(1)
+    expect(members[24][:member]).to eql('member_25')
+  end
+
+
+
   it 'should sort by rank if the :sort_by option is set to :rank' do
     rank_members_in_leaderboard(25)
 

--- a/spec/tie_ranking_leaderboard_spec.rb
+++ b/spec/tie_ranking_leaderboard_spec.rb
@@ -197,6 +197,69 @@ describe 'TieRankingLeaderboard' do
       end
     end
 
+    it 'should allow you to retrieve a given set of members from the leaderboard in a rank range' do
+      @leaderboard = TieRankingLeaderboard.new('ties', Leaderboard::DEFAULT_OPTIONS, {:host => "127.0.0.1", :db => 15})
+      rank_members_in_leaderboard(25)
+
+      members = @leaderboard.members_from_rank_range(5, 9)
+      expect(members.size).to be(5)
+      expect(members[0][:member]).to eql('member_21')
+      expect(members[0][:score].to_i).to be(21)
+      expect(members[4][:member]).to eql('member_17')
+
+      members = @leaderboard.members_from_rank_range(1, 1)
+      expect(members.size).to be(1)
+      expect(members[0][:member]).to eql('member_25')
+
+      members = @leaderboard.members_from_rank_range(-1, 26)
+      expect(members.size).to be(25)
+      expect(members[0][:member]).to eql('member_25')
+      expect(members[0][:score].to_i).to be(25)
+      expect(members[24][:member]).to eql('member_1')
+    end
+
+    it 'should allow you to retrieve a given set of members from the leaderboard in a range from 1 to the number given' do
+      @leaderboard = TieRankingLeaderboard.new('ties', Leaderboard::DEFAULT_OPTIONS, {:host => "127.0.0.1", :db => 15})
+      rank_members_in_leaderboard(25)
+
+      members = @leaderboard.top(5)
+      expect(members.size).to be(5)
+      expect(members[0][:member]).to eql('member_25')
+      expect(members[0][:score].to_i).to be(25)
+      expect(members[4][:member]).to eql('member_21')
+
+      members = @leaderboard.top(1)
+      expect(members.size).to be(1)
+      expect(members[0][:member]).to eql('member_25')
+
+      members = @leaderboard.top(26)
+      expect(members.size).to be(25)
+      expect(members[0][:member]).to eql('member_25')
+      expect(members[0][:score].to_i).to be(25)
+      expect(members[24][:member]).to eql('member_1')
+    end
+
+    it 'should allow you to retrieve a given set of members from the named leaderboard in a range from 1 to the number given' do
+      @leaderboard = TieRankingLeaderboard.new('name', Leaderboard::DEFAULT_OPTIONS, {:host => "127.0.0.1", :db => 15})
+      rank_members_in_leaderboard(25)
+
+      members = @leaderboard.top_in("name", 5)
+      expect(members.size).to be(5)
+      expect(members[0][:member]).to eql('member_25')
+      expect(members[0][:score].to_i).to be(25)
+      expect(members[4][:member]).to eql('member_21')
+
+      members = @leaderboard.top(1)
+      expect(members.size).to be(1)
+      expect(members[0][:member]).to eql('member_25')
+
+      members = @leaderboard.top(26)
+      expect(members.size).to be(25)
+      expect(members[0][:member]).to eql('member_25')
+      expect(members[0][:score].to_i).to be(25)
+      expect(members[24][:member]).to eql('member_1')
+    end
+
     it 'should expire the ties leaderboard in a given number of seconds' do
       @leaderboard = TieRankingLeaderboard.new('ties', Leaderboard::DEFAULT_OPTIONS, {:host => "127.0.0.1", :db => 15})
 


### PR DESCRIPTION
I just wanted to add a shorthand for get top_10 of a specific leaderboard, but this cover a general way:

```ruby
leaderboard.top_10
leaderboard.top_5
```

I'll add the test cases and proper document if this method fit with the library