### PR TITLE
Add global_member_data option that allows multiple leaderboards to share the same set of member_data

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,7 +52,8 @@ DEFAULT_OPTIONS = {
   :rank_key => :rank,
   :score_key => :score,
   :member_data_key => :member_data,
-  :member_data_namespace => 'member_data'
+  :member_data_namespace => 'member_data',
+  :global_member_data => false
 }
 ```
 

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -15,7 +15,8 @@ class Leaderboard
     :rank_key => :rank,
     :score_key => :score,
     :member_data_key => :member_data,
-    :member_data_namespace => 'member_data'
+    :member_data_namespace => 'member_data',
+    :global_member_data => false
   }
 
   # Default Redis host: localhost
@@ -80,6 +81,7 @@ class Leaderboard
     @score_key = leaderboard_options[:score_key]
     @member_data_key = leaderboard_options[:member_data_key]
     @member_data_namespace = leaderboard_options[:member_data_namespace]
+    @global_member_data = leaderboard_options[:global_member_data]
 
     @redis_connection = redis_options[:redis_connection]
     unless @redis_connection.nil?
@@ -974,7 +976,7 @@ class Leaderboard
   #
   # @return a key in the form of +leaderboard_name:member_data+
   def member_data_key(leaderboard_name)
-    "#{leaderboard_name}:#{@member_data_namespace}"
+    @global_member_data == false ? "#{leaderboard_name}:#{@member_data_namespace}" : @member_data_namespace
   end
 
   # Validate and return the page size. Returns the +DEFAULT_PAGE_SIZE+ if the page size is less than 1.

--- a/spec/leaderboard_spec.rb
+++ b/spec/leaderboard_spec.rb
@@ -767,4 +767,12 @@ describe 'Leaderboard' do
     expect(@redis_connection.exists("name:member_data")).to be_falsey
     expect(@redis_connection.exists("name:md")).to be_truthy
   end
+
+  it 'should allow you to have a global member data namespace' do
+    @leaderboard = Leaderboard.new('name', {:global_member_data => true}, {:host => "127.0.0.1", :db => 15})
+    rank_members_in_leaderboard
+
+    expect(@redis_connection.exists("member_data")).to be_truthy
+    expect(@redis_connection.exists("name:member_data")).to be_falsey
+  end
 end


### PR DESCRIPTION
We have a use case where we have a lot of leaderboards that have member data and the member data is all the same for the leaderboards.  This member data gets duplicated unnecessarily.  This patch allows multiple leaderboards to all share one set of member data.

Please review and let me know if there are any changes that you would like me to make.