### PR TITLE
More pipelining

### DIFF
--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -219,6 +219,26 @@ class Leaderboard
     @redis_connection.hget(member_data_key(leaderboard_name), member)
   end
 
+  # Retrieve the optional member data for a given member in the named leaderboard.
+  #
+  # @param leaderboard_name [String] Name of the leaderboard.
+  # @param members [Array] Member names.
+  #
+  # @return array of strings of optional member data.
+  def members_data_for_in(leaderboard_name, members)
+    return [] unless members.size > 0
+    @redis_connection.hmget(member_data_key(leaderboard_name), *members)
+  end
+
+  # Retrieve the optional member data for the given members in the leaderboard.
+  #
+  # @param members [Array] Member names.
+  #
+  # @return array of strings of optional member data.
+  def members_data_for(members)
+    members_data_for_in(@leaderboard_name, members)
+  end
+
   # Update the optional member data for a given member in the leaderboard.
   #
   # @param member [String] Member name.
@@ -964,11 +984,13 @@ class Leaderboard
         data[@score_key] = responses[index * 2 + 1].to_f if responses[index * 2 + 1]
       end
 
-      if leaderboard_options[:with_member_data]
-        data[@member_data_key] = member_data_for_in(leaderboard_name, member)
-      end
-
       ranks_for_members << data
+    end
+
+    if leaderboard_options[:with_member_data]
+      members_data_for_in(leaderboard_name, members).each_with_index do |member_data, index|
+        ranks_for_members[index][@member_data_key] = member_data
+      end
     end
 
     case leaderboard_options[:sort_by]

--- a/lib/tie_ranking_leaderboard.rb
+++ b/lib/tie_ranking_leaderboard.rb
@@ -249,11 +249,13 @@ class TieRankingLeaderboard < Leaderboard
         end
       end
 
-      if leaderboard_options[:with_member_data]
-        data[@member_data_key] = member_data_for_in(leaderboard_name, member)
-      end
-
       ranks_for_members << data
+    end
+
+    if leaderboard_options[:with_member_data]
+      members_data_for_in(leaderboard_name, members).each_with_index do |member_data, index|
+        ranks_for_members[index][@member_data_key] = member_data
+      end
     end
 
     case leaderboard_options[:sort_by]


### PR DESCRIPTION
hi there :). first off thanks so much for building this and sharing it with the world. i'm building a leaderboard and this gem made the process so much easier.

when I first set this up, I noticed that it's rather chatty fetching things from redis - some calls are pipelined and some are not, most notably the hgets and zcounts. so... I tweaked it to use hmget where appropriate and to pipeline the zcounts where possible, and the result is that the endpoint we have serving up our leaderboards has response times that are ~20% of what they were before these tweaks (we serve up 3 different leaderboards and display both the top 100 and the ten players around a given logged in player).

i tried to follow the style/documentation y'all used, feel free to let me know if it's not up to snuff, I'm happy to fix it if it isn't. the specs all pass.

cheers and thanks again!
